### PR TITLE
Revert "use Pytree as base type in nnx_wrappers"

### DIFF
--- a/src/MaxText/layers/nnx_wrappers.py
+++ b/src/MaxText/layers/nnx_wrappers.py
@@ -29,7 +29,7 @@ from flax.nnx import graph
 from flax.nnx import variablelib
 from flax.nnx.bridge import module as bdg_module
 from flax.nnx.module import Module
-from flax.nnx import Object #TODO(gulsumgudukbay) convert this import to from flax.nnx import Pytree after ROCm/jax supports flax >= 0.11.0
+from flax.nnx import Object # TODO(gulsumgudukbay) convert this import to from flax.nnx import Pytree after ROCm/jax supports flax >= 0.11.0
 from flax.nnx.rnglib import Rngs
 import jax
 from jax import tree_util as jtu


### PR DESCRIPTION
# Description

This reverts commit 8840296efac95908c722695929a19491138dc9f0. This commit was using Pytree as base type in nnx_wrappers. Currently, with JAX 0.6.0 on ROCm, the latest flax version supported is 0.10.7, hence this commit is not valid and breaks the execution.

**_Note: This commit should be reverted when flax version is upgraded to anything >= 0.11.0. Right now, JAX 0.6.0 does not support any flax version >= 0.10.7, hence this commit is required as flax started exposing PyTree after 0.11.0._**

*Notice 1:* Once all tests pass, the "pull ready" label will automatically be assigned.
This label is used for administrative purposes. Please do not add it manually.

*Notice 2:* For external contributions, our settings currently require an approval from a MaxText maintainer to trigger CI tests.

# Tests

I ran train.py with the following args:
python -m MaxText.train MaxText/configs/base.yml run_name=test hardware=gpu steps=5 model_name=llama2-7b attention=cudnn_flash_te enable_checkpointing=False ici_expert_parallelism=1  ici_fsdp_parallelism=-1  ici_data_parallelism=1 remat_policy=minimal scan_layers=True dataset_type=synthetic logits_dot_in_fp32=False dtype=bfloat16 weight_dtype=bfloat16 per_device_batch_size=1 max_target_length=2048  shardy=False

It was able to successfully complete execution.

# Checklist

Before submitting this PR, please make sure (put X in square brackets):
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed.
