### PR TITLE
[DECOUPLED-MODE] test(checkpointing): patch GCS Client via load_dynamic.storage for decoupled

### DIFF
--- a/tests/unit/checkpointing_test.py
+++ b/tests/unit/checkpointing_test.py
@@ -145,7 +145,7 @@ class LoadDynamicTest(parameterized.TestCase):
   """Tests for cache downloads and dynamic loading of safetensors."""
 
   @mock.patch("huggingface_hub.HfFileSystem")
-  @mock.patch("google.cloud.storage.Client")
+  @mock.patch.object(load_dynamic.storage, "Client")
   def test_build_gcs_cache_worker_cache_hit(self, mock_storage_client, mock_hf_fs):
     mock_client_instance = mock_storage_client.return_value
     mock_bucket = mock_client_instance.bucket.return_value
@@ -157,7 +157,7 @@ class LoadDynamicTest(parameterized.TestCase):
     mock_blob.upload_from_file.assert_not_called()
 
   @mock.patch("huggingface_hub.HfFileSystem")
-  @mock.patch("google.cloud.storage.Client")
+  @mock.patch.object(load_dynamic.storage, "Client")
   def test_build_gcs_cache_worker_cache_miss_success(self, mock_storage_client, mock_hf_fs):
     mock_fs_instance = mock_hf_fs.return_value
     mock_remote_file = mock.MagicMock()
@@ -173,7 +173,7 @@ class LoadDynamicTest(parameterized.TestCase):
     mock_blob.upload_from_file.assert_called_once_with(mock_remote_file, client=mock_client_instance)
 
   @mock.patch("huggingface_hub.HfFileSystem")
-  @mock.patch("google.cloud.storage.Client")
+  @mock.patch.object(load_dynamic.storage, "Client")
   def test_build_gcs_cache_worker_retry_and_fail(self, mock_storage_client, mock_hf_fs):
     mock_fs_instance = mock_hf_fs.return_value
     mock_fs_instance.open.side_effect = Exception("Download failed")


### PR DESCRIPTION
# Description

Fix the `LoadDynamicTest.test_build_gcs_cache_worker_*` tests to run in decoupled environments (`DECOUPLE_GCLOUD=TRUE`), where `google-cloud-storage` is absent.

`google.cloud.storage.Client` was patched, which fails to resolve at patch time when the library isn't installed. Switched to
`@mock.patch.object(load_dynamic.storage, "Client")`, patching the module-level binding instead, matching the existing `load_safetensors_dynamic_state` test and working in both decoupled and non-decoupled modes.

# Tests

Ran in the ROCm TheRock 7.14 decoupled container: `pytest tests/unit/checkpointing_test.py::LoadDynamicTest`: 4 passed.
Full decoupled suite: 866 passed, 0 failed.

# Checklist
Before submitting this PR, please make sure (put X in square brackets):
- [X] I have performed a self-review of my code. For an optional AI review, add the `gemini-review` label.
- [X] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have run end-to-end tests tests and provided workload links above if applicable.
- [x] I have made or will make corresponding changes to the doc if needed, including adding new documentation pages to the relevant Table of Contents (toctree directive) as explained in [our documentation](https://maxtext.readthedocs.io/en/latest/development.html#adding-new-documentation-files).